### PR TITLE
Improve OpenGL library loading

### DIFF
--- a/src/video/SDL_video.c
+++ b/src/video/SDL_video.c
@@ -3029,8 +3029,13 @@ SDL_GL_ResetAttributes()
                                        &_this->gl_config.minor_version);
     } else {
 #if SDL_VIDEO_OPENGL
+#ifdef __AMIGAOS4__
+        _this->gl_config.major_version = 1; /* MiniGL */
+        _this->gl_config.minor_version = 3;
+#else
         _this->gl_config.major_version = 2;
         _this->gl_config.minor_version = 1;
+#endif
         _this->gl_config.profile_mask = 0;
 #elif SDL_VIDEO_OPENGL_ES2
         _this->gl_config.major_version = 2;

--- a/src/video/amigaos4/SDL_os4video.c
+++ b/src/video/amigaos4/SDL_os4video.c
@@ -1,6 +1,6 @@
 /*
   Simple DirectMedia Layer
-  Copyright (C) 1997-2017 Sam Lantinga <slouken@libsdl.org>
+  Copyright (C) 1997-2018 Sam Lantinga <slouken@libsdl.org>
 
   This software is provided 'as-is', without any express or implied
   warranty.  In no event will the authors be held liable for any damages
@@ -288,6 +288,19 @@ OS4_SetGLESFunctions(SDL_VideoDevice * device)
 }
 #endif
 
+static SDL_bool
+OS4_IsMiniGL(_THIS)
+{
+    if ((_this->gl_config.profile_mask == 0) &&
+        (_this->gl_config.major_version == 1) &&
+        (_this->gl_config.minor_version == 3)) {
+            dprintf("OpenGL 1.3 requested\n");
+            return SDL_TRUE;
+    }
+
+    return SDL_FALSE;
+}
+
 #if SDL_VIDEO_OPENGL_ES2
 static SDL_bool
 OS4_IsOpenGLES2(_THIS)
@@ -311,16 +324,20 @@ OS4_LoadGlLibrary(_THIS, const char * path)
         _this->gl_config.major_version,
         _this->gl_config.minor_version);
 
+    if (OS4_IsMiniGL(_this)) {
+        OS4_SetMiniGLFunctions(_this);
+        return OS4_GL_LoadLibrary(_this, path);
+    }
+
 #if SDL_VIDEO_OPENGL_ES2
     if (OS4_IsOpenGLES2(_this)) {
         OS4_SetGLESFunctions(_this);
         return OS4_GLES_LoadLibrary(_this, path);
-    } else {
-        OS4_SetMiniGLFunctions(_this);
     }
 #endif
 
-    return OS4_GL_LoadLibrary(_this, path);
+    dprintf("Invalid OpenGL version\n");
+    return -1;
 }
 
 static SDL_VideoDevice *

--- a/src/video/amigaos4/SDL_os4video.c
+++ b/src/video/amigaos4/SDL_os4video.c
@@ -337,6 +337,7 @@ OS4_LoadGlLibrary(_THIS, const char * path)
 #endif
 
     dprintf("Invalid OpenGL version\n");
+    SDL_SetError("Invalid OpenGL version");
     return -1;
 }
 

--- a/test/helloworld.c
+++ b/test/helloworld.c
@@ -350,7 +350,10 @@ static void testOpenGLES2()
 static void testOpenGLSwitching()
 {
     SDL_Window* w = createWindow("Centered & Resizable OpenGL window");
-    SDL_DestroyWindow(w);
+
+    if (w) {
+        SDL_DestroyWindow(w);
+    }
 
     // Switch to OGLES2
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, SDL_GL_CONTEXT_PROFILE_ES);
@@ -358,12 +361,15 @@ static void testOpenGLSwitching()
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
 
     w = createWindow("Centered & Resizable OGLES2 window");
-    SDL_DestroyWindow(w);
 
-    // Switch back to "any" OpenGL
+    if (w) {
+        SDL_DestroyWindow(w);
+    }
+
+    // Switch back to MiniGL
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, 0);
     SDL_GL_SetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, 1);
-    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 0);
+    SDL_GL_SetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, 3);
 
     w = createWindow("Centered & Resizable OpenGL window");
 
@@ -380,6 +386,17 @@ static void testFullscreenOpenGL()
         SDL_WINDOW_FULLSCREEN | SDL_WINDOW_OPENGL);
 
     drawUsingFixedFunctionPipeline(w);
+}
+
+static void testOpenGLVersion()
+{
+    int mask, major, minor;
+
+    SDL_GL_GetAttribute(SDL_GL_CONTEXT_PROFILE_MASK, &mask);
+    SDL_GL_GetAttribute(SDL_GL_CONTEXT_MAJOR_VERSION, &major);
+    SDL_GL_GetAttribute(SDL_GL_CONTEXT_MINOR_VERSION, &minor);
+
+    printf("Current GL mask %d, major version %d, minor version %d\n", mask, major, minor);
 }
 
 static void testRenderer()
@@ -789,6 +806,7 @@ int main(void)
         //testOpenGL();
         //testOpenGLES2();
         testOpenGLSwitching();
+        //testOpenGLVersion();
         //testRenderer();
         //testDraw();
         //testMessageBox();

--- a/test/helloworld.c
+++ b/test/helloworld.c
@@ -364,6 +364,8 @@ static void testOpenGLSwitching()
 
     if (w) {
         SDL_DestroyWindow(w);
+    } else {
+        printf("%s\n", SDL_GetError());
     }
 
     // Switch back to MiniGL


### PR DESCRIPTION
OpenGL default version is now 1.3 (similar to MiniGL) and there is no more falling back to MiniGL, in case required version doesn't match.